### PR TITLE
fix: properly extract options

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -181,7 +181,7 @@ exports.run = function(options) {
 
 	config.project = project.info(options.projectDir);
 	config.language = options.language || null;
-	config.apply = options.apply || false;
+	config.apply = options.opts().apply || false;
 
 	// languages to merge with
 	var languages = config.language ? [config.language] : i18n.getLanguages(path.join(config.project.path, 'app', 'i18n'));

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -73,7 +73,7 @@ exports.run = function(options) {
 	// log table
 	console.log(table.toString());
 
-	if (options.apply) {
+	if (options.opts().apply) {
 
 		if (_.size(update) > 0) {
 			strings.update(target_path, update);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -47,7 +47,7 @@ exports.run = function(options) {
 		if (strings_language_missing[language].length > 0) {
 			strings_missing = _.union(strings_missing, strings_language_missing[language]);
 
-			if (options.apply) {
+			if (options.opts().apply) {
 				strings.append(paths_language[language], strings_missing);
 			}
 		}


### PR DESCRIPTION
The library failed to honor the `--apply` option using Node.js 16+, so maybe something changed here. With this fix, it's working fine again