### PR TITLE
fix: support new es features when parsing controllers

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -90,7 +90,8 @@ function extractFromController(file_path) {
 	var strings = [];  
 
 	var result = Parser.parse(fs.readFileSync(file_path, 'utf8'), {
-		sourceType: 'module'
+		sourceType: 'module',
+		ecmaVersion: 11
 	});
 
 	walk.simple(result, {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "preferGlobal": true,
   "dependencies": {
-    "acorn": "^6.0.4",
-    "acorn-jsx": "^5.0.1",
-    "acorn-walk": "^6.1.1",
+    "acorn": "^8.8.1",
+    "acorn-jsx": "^5.3.2",
+    "acorn-walk": "^8.2.0",
     "alloy": "^1.14.5",
     "ascii-table": ">=0.0.1",
     "colors": ">=0.6.0-1",


### PR DESCRIPTION
Bumps acorn to support syntax from new ECMAScript versions and set the default version to 11 (2020), e.g. to support optional chaining and nullish coalescing operator in controllers.